### PR TITLE
Add Skills section to portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Cosmic Portfolio is a responsive, single-page application designed to present a 
 * **Comprehensive Sections**:
   * Hero section with a captivating introduction.
   * Detailed listings for Projects (GitHub and custom).
+  * Skills showcase highlighting key technologies.
   * Integrated Blogs section.
   * Certifications and Publications.
   * Interactive Timeline for education and professional experience.
@@ -135,7 +136,7 @@ In the project directory, you can run the following scripts:
 Most personal information and content can be customized by editing the `src/config/personalInfo.js` file. This includes:
 
 * Name, professional title, contact email, and social media links.
-* Details for education, work experience, and skills.
+* Details for education, work experience, and skills (including the tech stack).
 * Content for custom projects and publications.
 
 Theme settings (colors, fonts, etc.) can be adjusted in `src/config/theme.js` and `src/styles/GlobalStyles.js`.

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import personalInfo from './config/personalInfo';
 import CosmicBackground from './components/CosmicBackground';
 import Navigation from './components/Navigation';
 import Hero from './sections/Hero';
+import Skills from './sections/Skills';
 import Timeline from './sections/Timeline';
 import Projects from './sections/Projects';
 import Blogs from './sections/Blogs';
@@ -42,7 +43,7 @@ function App() {
           <CosmicBackground />
           <Navigation />
           <div className="App">
-            <Hero 
+            <Hero
               name={personalInfo.name}
               skills={personalInfo.skills}
               description={personalInfo.description}
@@ -52,7 +53,8 @@ function App() {
               blog={personalInfo.blog}
               cv={personalInfo.cv}
             />
-            <Timeline 
+            <Skills />
+            <Timeline
               education={personalInfo.education}
               experience={personalInfo.experience}
             />

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -124,6 +124,7 @@ const Navigation = () => {
     { name: 'Home', href: '#home' },
     { name: 'Timeline', href: '#timeline' },
     { name: 'Projects', href: '#projects' },
+    { name: 'Skills', href: '#skills' },
     { name: 'Blogs', href: '#blogs' },
     { name: 'Publications', href: '#publications' },
     // { name: 'Certifications', href: '#certifications' },

--- a/src/config/personalInfo.js
+++ b/src/config/personalInfo.js
@@ -21,6 +21,20 @@ const personalInfo = {
     "Geography Nerd",
   ],
 
+  // Technologies and tools for dedicated Skills section
+  techStack: [
+    "JavaScript",
+    "Python",
+    "Java",
+    "React",
+    "Node.js",
+    "Go",
+    "PostgreSQL",
+    "Three.js",
+    "TensorFlow",
+    "Docker"
+  ],
+
   // Education
   education: [
     {

--- a/src/sections/Skills.js
+++ b/src/sections/Skills.js
@@ -4,12 +4,12 @@ import { motion, useAnimation, useInView } from 'framer-motion';
 import {
   SiJavascript,
   SiPython,
-  SiJava,
+  SiOpenjdk,
   SiReact,
   SiNodedotjs,
   SiGo,
   SiPostgresql,
-  SiThreejs,
+  SiThreedotjs,
   SiTensorflow,
   SiDocker
 } from 'react-icons/si';
@@ -71,12 +71,12 @@ const SkillName = styled.p`
 const iconMap = {
   'JavaScript': SiJavascript,
   'Python': SiPython,
-  'Java': SiJava,
+  'Java': SiOpenjdk,
   'React': SiReact,
   'Node.js': SiNodedotjs,
   'Go': SiGo,
   'PostgreSQL': SiPostgresql,
-  'Three.js': SiThreejs,
+  'Three.js': SiThreedotjs,
   'TensorFlow': SiTensorflow,
   'Docker': SiDocker,
 };

--- a/src/sections/Skills.js
+++ b/src/sections/Skills.js
@@ -1,0 +1,156 @@
+import React, { useRef, useEffect } from 'react';
+import styled from 'styled-components';
+import { motion, useAnimation, useInView } from 'framer-motion';
+import {
+  SiJavascript,
+  SiPython,
+  SiJava,
+  SiReact,
+  SiNodedotjs,
+  SiGo,
+  SiPostgresql,
+  SiThreejs,
+  SiTensorflow,
+  SiDocker
+} from 'react-icons/si';
+import personalInfo from '../config/personalInfo';
+
+const SkillsSection = styled.section`
+  padding: 6rem 2rem;
+  position: relative;
+  overflow: hidden;
+  @media (max-width: ${props => props.theme.breakpoints.tablet}) {
+    padding: 2rem 2rem;
+  }
+`;
+
+const SectionTitle = styled(motion.h2)`
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  text-align: center;
+  margin-bottom: 1rem;
+  background: ${props => props.theme.gradients.nebula};
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+`;
+
+const SectionSubtitle = styled(motion.p)`
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto 4rem;
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.8);
+`;
+
+const SkillsGrid = styled(motion.div)`
+  max-width: 900px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 2rem;
+  justify-items: center;
+`;
+
+const SkillCard = styled(motion.div)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const SkillIcon = styled.div`
+  font-size: 3rem;
+  color: ${props => props.theme.colors.primary};
+`;
+
+const SkillName = styled.p`
+  color: ${props => props.theme.colors.light};
+  font-size: 0.9rem;
+  text-align: center;
+`;
+
+const iconMap = {
+  'JavaScript': SiJavascript,
+  'Python': SiPython,
+  'Java': SiJava,
+  'React': SiReact,
+  'Node.js': SiNodedotjs,
+  'Go': SiGo,
+  'PostgreSQL': SiPostgresql,
+  'Three.js': SiThreejs,
+  'TensorFlow': SiTensorflow,
+  'Docker': SiDocker,
+};
+
+const Skills = () => {
+  const { techStack } = personalInfo;
+  const controls = useAnimation();
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: false, threshold: 0.2 });
+
+  useEffect(() => {
+    if (inView) {
+      controls.start('visible');
+    }
+  }, [controls, inView]);
+
+  const titleVariants = {
+    hidden: { opacity: 0, y: -30 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: { duration: 0.5, ease: 'easeOut' }
+    }
+  };
+
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        staggerChildren: 0.1,
+        delayChildren: 0.2
+      }
+    }
+  };
+
+  const itemVariants = {
+    hidden: { opacity: 0, y: 20 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        type: 'spring',
+        stiffness: 120,
+        damping: 10
+      }
+    }
+  };
+
+  if (!techStack || techStack.length === 0) {
+    return null;
+  }
+
+  return (
+    <SkillsSection id="skills" ref={ref}>
+      <SectionTitle variants={titleVariants} initial="hidden" animate={controls}>
+        Skills
+      </SectionTitle>
+      <SectionSubtitle variants={titleVariants} initial="hidden" animate={controls}>
+        Technologies and tools I frequently work with
+      </SectionSubtitle>
+      <SkillsGrid variants={containerVariants} initial="hidden" animate={controls}>
+        {techStack.map((skill) => {
+          const Icon = iconMap[skill] || SiJavascript;
+          return (
+            <SkillCard key={skill} variants={itemVariants}>
+              <SkillIcon><Icon /></SkillIcon>
+              <SkillName>{skill}</SkillName>
+            </SkillCard>
+          );
+        })}
+      </SkillsGrid>
+    </SkillsSection>
+  );
+};
+
+export default Skills;


### PR DESCRIPTION
## Summary
- list tech stack in personal information
- showcase skills via new Skills section
- link new section in navigation and app layout
- document skills section in README

## Testing
- `npm test --silent` *(fails: ResizeObserver not supported)*

------
https://chatgpt.com/codex/tasks/task_e_685bf8a82bb08329ad8e957f1e0961ea