### PR TITLE
Fix moon component comment

### DIFF
--- a/src/components/CosmicLoader.js
+++ b/src/components/CosmicLoader.js
@@ -107,8 +107,8 @@ const GentleStars = ({ count = 100 }) => {
   );
 };
 
-// Earth globe component with minimal continent outlines
-const Earth = () => {
+// Moon globe component rendered with lunar texture
+const Moon = () => {
     const mesh = React.useRef();
     const texture = useLoader(THREE.TextureLoader, '/textures/2k_moon.jpg');
 
@@ -133,7 +133,7 @@ const StarField = () => {
     <>
       <ambientLight intensity={0.3} />
       <pointLight position={[10, 5, 10]} intensity={0.6} />
-      <Earth />
+      <Moon />
       <GentleStars count={150} />
 
       <EffectComposer>


### PR DESCRIPTION
## Summary
- clarify comment for moon component in `CosmicLoader`
- rename the component from `Earth` to `Moon`

## Testing
- `CI=true npm test --silent` *(fails: ResizeObserver not supported)*

------
https://chatgpt.com/codex/tasks/task_e_685c06610908832997664c37dab40781