### PR TITLE
Update App test to check for navigation logo

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,35 @@
-import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+// Mock heavy components to speed up tests and avoid side effects
+jest.mock('./components/CosmicLoader', () => () => <div>Loading...</div>);
+jest.mock('./components/CosmicBackground', () => () => <div />);
+jest.mock('./sections/Hero', () => () => <div />);
+jest.mock('./sections/Skills', () => () => <div />);
+jest.mock('./sections/Timeline', () => () => <div />);
+jest.mock('./sections/Projects', () => () => <div />);
+jest.mock('./sections/Blogs', () => () => <div />);
+jest.mock('./sections/Publications', () => () => <div />);
+jest.mock('./sections/Certifications', () => () => <div />);
+jest.mock('./sections/CosmicJourneys', () => () => <div />);
+jest.mock('./sections/Contact', () => () => <div />);
+jest.mock('./components/Footer', () => () => <div />);
+
+test('renders navigation logo text', async () => {
+  jest.useFakeTimers();
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+
+  // Fast-forward timers to skip the loader
+  act(() => {
+    jest.runAllTimers();
+  });
+
+  const logoElement = await screen.findByText((content, element) => {
+    const text = element.textContent.replace(/\s+/g, '');
+    return text.toLowerCase() === 'anay.live';
+  });
+  expect(logoElement).toBeInTheDocument();
+
+  jest.useRealTimers();
 });


### PR DESCRIPTION
## Summary
- assert navigation logo text in `App` test
- mock heavy components for faster tests

## Testing
- `CI=true npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_685c067020788329ac9d088c9da4312c