### PR TITLE
Fix githubUsername default

### DIFF
--- a/src/sections/Projects.js
+++ b/src/sections/Projects.js
@@ -260,7 +260,7 @@ const ViewAllButton = styled(motion.a)`
   }
 `;
 
-const Projects = ({ githubUsername = [] }) => {
+const Projects = ({ githubUsername = '' }) => {
   const customProjects = personalInfo.customProjects || [];
   const controls = useAnimation();
   const ref = useRef(null);


### PR DESCRIPTION
## Summary
- default `githubUsername` prop to an empty string

## Testing
- `CI=true npm test --silent -- --watchAll=false` *(fails: ResizeObserver not supported)*

------
https://chatgpt.com/codex/tasks/task_e_685c0677635c8329bbee78bfff388863