### PR TITLE
Fix ProjectTags display property

### DIFF
--- a/src/sections/Projects.js
+++ b/src/sections/Projects.js
@@ -204,9 +204,9 @@ const ProjectTags = styled.div`
   flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: 0.7rem;
-  margin-bottom: 1rem; 
+  margin-bottom: 1rem;
   @media (max-width: ${props => props.theme.breakpoints.tablet}) {
-    display: None;
+    display: none;
   }
 `;
 


### PR DESCRIPTION
## Summary
- correct display property in mobile view for `ProjectTags`

## Testing
- `npm test` *(fails: This browser does not support ResizeObserver out of the box)*

------
https://chatgpt.com/codex/tasks/task_e_685c067825a483299c88070dcc78b693